### PR TITLE
adding Package.swift to make our pod repo compatible with swiftpm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "RiveRuntime",
+    platforms: [.iOS("10.0"), .macOS("10.15")],
+    products: [
+        .library(
+            name: "RiveRuntime",
+            targets: ["RiveRuntime"])],
+    targets: [
+        .binaryTarget(
+            name: "RiveRuntime",
+            path: "RiveRuntime.xcframework"
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "RiveRuntime",
-    platforms: [.iOS("10.0"), .macOS("10.15")],
+    platforms: [.iOS("10.0")],
     products: [
         .library(
             name: "RiveRuntime",


### PR DESCRIPTION
(for now) rive-ios pushes a new xcframework on deploy (on merge to master) this reflects what was setup in my fork https://github.com/mjtalbot/rive-ios-pod/blob/main/Package.swift